### PR TITLE
Deleted external brake function

### DIFF
--- a/commissioning/commissioning.py
+++ b/commissioning/commissioning.py
@@ -284,11 +284,6 @@ def update_motor_speed_PID():
     check("setSWDParameters()", error)
 
 
-def update_external_brake_parameters():
-    error = can_open_client.setValueBool(0x2660_00_01, 0)   # 0: external brake is not connected 1: external brake is connected
-    check("update_external_brake()", error)
-
-
 def update_error_behavior():
     error = can_open_client.setValueUInt8(0x1029_02_00, 1)  # error_behavior_syserr_for_error => 1 (no change of the NMT state)
     check("update_error_behavior()", error)

--- a/commissioning/swd_left_4_commissioning.py
+++ b/commissioning/swd_left_4_commissioning.py
@@ -193,11 +193,6 @@ def main(argv):
     commissioning.update_motor_speed_PID()
 
     #
-    # Update external brake parameters
-    #
-    # commissioning.update_external_brake_parameters()
-
-    #
     # Update error behavior
     #
     commissioning.update_error_behavior()

--- a/commissioning/swd_right_5_commissioning.py
+++ b/commissioning/swd_right_5_commissioning.py
@@ -192,11 +192,6 @@ def main(argv):
     commissioning.update_motor_speed_PID()
 
     #
-    # Update external brake parameters
-    #
-    # commissioning.update_external_brake_parameters()
-
-    #
     # Update error behavior
     #
     commissioning.update_error_behavior()

--- a/commissioning/two_lidars_swd_left_4_commissioning.py
+++ b/commissioning/two_lidars_swd_left_4_commissioning.py
@@ -196,10 +196,6 @@ def main(argv):
     #
     commissioning.update_motor_speed_PID()
 
-    #
-    # Update external brake parameters
-    #
-    # commissioning.update_external_brake_parameters()
 
     #
     # Update error behavior

--- a/commissioning/two_lidars_swd_right_5_commissioning.py
+++ b/commissioning/two_lidars_swd_right_5_commissioning.py
@@ -196,11 +196,6 @@ def main(argv):
     commissioning.update_motor_speed_PID()
 
     #
-    # Update external brake parameters
-    #
-    # commissioning.update_external_brake_parameters()
-
-    #
     # Update error behavior
     #
     commissioning.update_error_behavior()


### PR DESCRIPTION
Normally, user cannot add or remove external brake. Therefore, the function changing external brake is not needed.