### PR TITLE
Change the settings

### DIFF
--- a/commissioning/commissioning.py
+++ b/commissioning/commissioning.py
@@ -59,8 +59,10 @@ def update_network_parameters(node_id: int):
     network = NetworkParameters()
 
     network.node_id = node_id
-    network.bit_timing = BitTiming.BT_1000
     network.rt_activated = True
+
+    error = can_open_client.setValueInt8(0x2100_00_08, BitTiming.BT_1000)
+    check(f"setNetworkParameters(bit_timing)", error)
 
     error = communication_client.setNetworkParameters(network)
     check(f"setNetworkParameters(node_id={node_id})", error)

--- a/commissioning/commissioning.py
+++ b/commissioning/commissioning.py
@@ -287,7 +287,8 @@ def update_motor_speed_PID():
 
 
 def update_error_behavior():
-    error = can_open_client.setValueUInt8(0x1029_02_00, 1)  # error_behavior_syserr_for_error => 1 (no change of the NMT state)
+	# error_behavior_syserr_for_error => 0 (the node enters the NMT 'pre-Operational' state)
+    error = can_open_client.setValueUInt8(0x1029_02_00, 0)
     check("update_error_behavior()", error)
 
 

--- a/commissioning/swd_left_4_commissioning.py
+++ b/commissioning/swd_left_4_commissioning.py
@@ -101,25 +101,25 @@ def main(argv):
     # SLS parameters
     sls_1_vl_limit = 680
     sls_1_vl_time_monitoring = 1000
-    sls_1_sto_error_reaction = False
+    sls_1_sto_error_reaction = True
     sls_2_vl_limit = 850
     sls_2_vl_time_monitoring = 1000
-    sls_2_sto_error_reaction = False
+    sls_2_sto_error_reaction = True
 
     # SLSa parameters 
     slsa_1_p_vl_limit = 100
     slsa_1_n_vl_limit = 680
     slsa_1_vl_time_monitoring = 1000
-    slsa_1_sto_error_reaction = False
+    slsa_1_sto_error_reaction = True
     slsa_2_p_vl_limit = 100
     slsa_2_n_vl_limit = 680
     slsa_2_vl_time_monitoring = 1000
-    slsa_2_sto_error_reaction = False
+    slsa_2_sto_error_reaction = True
 
     # SMS parameters
     sms_p_vl_limit = 1400
     sms_n_vl_limit = 1400
-    sms_sto_error_reaction = False 
+    sms_sto_error_reaction = True
 
     # Create DBus clients
     commissioning.create_dbus_clients(instance_id)

--- a/commissioning/swd_right_5_commissioning.py
+++ b/commissioning/swd_right_5_commissioning.py
@@ -101,25 +101,25 @@ def main(argv):
     # SLS parameters
     sls_1_vl_limit = 680
     sls_1_vl_time_monitoring = 1000
-    sls_1_sto_error_reaction = False
+    sls_1_sto_error_reaction = True
     sls_2_vl_limit = 850
     sls_2_vl_time_monitoring = 1000
-    sls_2_sto_error_reaction = False
+    sls_2_sto_error_reaction = True
 
     # SLSa parameters 
     slsa_1_p_vl_limit = 680
     slsa_1_n_vl_limit = 100
     slsa_1_vl_time_monitoring = 1000
-    slsa_1_sto_error_reaction = False
+    slsa_1_sto_error_reaction = True
     slsa_2_p_vl_limit = 680
     slsa_2_n_vl_limit = 100
     slsa_2_vl_time_monitoring = 1000
-    slsa_2_sto_error_reaction = False
+    slsa_2_sto_error_reaction = True
 
     # SMS parameters
     sms_p_vl_limit = 1400
     sms_n_vl_limit = 1400
-    sms_sto_error_reaction = False 
+    sms_sto_error_reaction = True
 
     # Create DBus clients
     commissioning.create_dbus_clients(instance_id)

--- a/commissioning/two_lidars_swd_left_4_commissioning.py
+++ b/commissioning/two_lidars_swd_left_4_commissioning.py
@@ -105,25 +105,25 @@ def main(argv):
     # SLS parameters
     sls_1_vl_limit = 680
     sls_1_vl_time_monitoring = 1000
-    sls_1_sto_error_reaction = False
+    sls_1_sto_error_reaction = True
     sls_2_vl_limit = 850
     sls_2_vl_time_monitoring = 1000
-    sls_2_sto_error_reaction = False
+    sls_2_sto_error_reaction = True
 
     # SLSa parameters 
     slsa_1_p_vl_limit = 100
     slsa_1_n_vl_limit = 680
     slsa_1_vl_time_monitoring = 1000
-    slsa_1_sto_error_reaction = False
+    slsa_1_sto_error_reaction = True
     slsa_2_p_vl_limit = 100
     slsa_2_n_vl_limit = 680
     slsa_2_vl_time_monitoring = 1000
-    slsa_2_sto_error_reaction = False
+    slsa_2_sto_error_reaction = True
 
     # SMS parameters
     sms_p_vl_limit = 1400
     sms_n_vl_limit = 1400
-    sms_sto_error_reaction = False 
+    sms_sto_error_reaction = True
 
     # Create DBus clients
     commissioning.create_dbus_clients(instance_id)

--- a/commissioning/two_lidars_swd_right_5_commissioning.py
+++ b/commissioning/two_lidars_swd_right_5_commissioning.py
@@ -105,25 +105,25 @@ def main(argv):
     # SLS parameters
     sls_1_vl_limit = 680
     sls_1_vl_time_monitoring = 1000
-    sls_1_sto_error_reaction = False
+    sls_1_sto_error_reaction = True
     sls_2_vl_limit = 850
     sls_2_vl_time_monitoring = 1000
-    sls_2_sto_error_reaction = False
+    sls_2_sto_error_reaction = True
 
     # SLSa parameters 
     slsa_1_p_vl_limit = 680
     slsa_1_n_vl_limit = 100
     slsa_1_vl_time_monitoring = 1000
-    slsa_1_sto_error_reaction = False
+    slsa_1_sto_error_reaction = True
     slsa_2_p_vl_limit = 680
     slsa_2_n_vl_limit = 100
     slsa_2_vl_time_monitoring = 1000
-    slsa_2_sto_error_reaction = False
+    slsa_2_sto_error_reaction = True
 
     # SMS parameters
     sms_p_vl_limit = 1400
     sms_n_vl_limit = 1400
-    sms_sto_error_reaction = False 
+    sms_sto_error_reaction = True
 
     # Create DBus clients
     commissioning.create_dbus_clients(instance_id)


### PR DESCRIPTION
- Changed communication speed setting to access registers directly
- Modified error behavior: transition to NMT 'pre-Operational' state upon error
- Fixed default value of sto_error_reaction parameter